### PR TITLE
Detect stale observers

### DIFF
--- a/src/Observers.cpp
+++ b/src/Observers.cpp
@@ -3,4 +3,35 @@
 namespace Coap
 {
 
+    uint32_t Observer::getNextSequentialNumber()
+    {
+        unsigned long currentTime = millis();
+        return currentTime & 0xFFFFFF; // Return only the least significant 24 bits.
+    }
+
+    void Observer::setActive(bool active)
+    {
+        this->_active = active;
+        if (active)
+        {
+            // If the observer is set as active, update the last seen timestamp to the current time,
+            // as we assume that the observer is set as active after the registration is confirmed.
+            this->_lastSeen = millis();
+        }
+    }
+
+    bool Observer::isStale() const
+    {
+        if (!this->_active)
+        {
+            // Inactive observers are not considered stale.
+            return false;
+        }
+
+        unsigned long currentTime = millis();
+        unsigned long elapsedTime = currentTime - this->_lastSeen; // Wrapping is safe.
+
+        // Check if the elapsed time since the last seen timestamp exceeds 24 hours (in milliseconds).
+        return elapsedTime > (24UL * 60UL * 60UL * 1000UL);
+    }
 }

--- a/src/Observers.h
+++ b/src/Observers.h
@@ -48,6 +48,10 @@ namespace Coap
          * Note that a value of zero may still be valid.
          */
         uint8_t _tokenLength = 0;
+        /**
+         * @brief Last seen timestamp in milliseconds.
+         */
+        unsigned long _lastSeen = 0;
 
     public:
         /**
@@ -64,10 +68,11 @@ namespace Coap
          * @param tokenLength The length of the token in bytes.
          */
         Observer(IPAddress ip, uint16_t port, const uint8_t *token, uint8_t tokenLength)
-            : _active(true), _ip(ip), _port(port), _tokenLength(tokenLength)
+            : _ip(ip), _port(port), _tokenLength(tokenLength)
         {
             // Copy the token value, ensuring that we do not exceed the maximum token length.
             memcpy(this->_token, token, tokenLength > COAP_MAX_TOKEN_LENGTH ? COAP_MAX_TOKEN_LENGTH : tokenLength);
+            this->setActive(true);
         }
 
         /**
@@ -82,15 +87,22 @@ namespace Coap
         }
 
         /**
+         * @brief Check if the observer is considered stale.
+         * @return True if the observer is stale, false otherwise.
+         *
+         * An observer is considered stale if it has not been seen for more than 24 hours.
+         * @see https://datatracker.ietf.org/doc/html/rfc7641#section-4.5
+         */
+        bool isStale() const;
+
+        /**
          * @brief Set the observer as active or inactive.
          * @param active True to set the observer as active, false to set it as inactive.
          *
+         * Setting an observer as active also updates its internal last seen value.
          * Inactive observers are ignored by the registry and their slot can be reused to store new observers.
          */
-        void setActive(bool active)
-        {
-            this->_active = active;
-        }
+        void setActive(bool active);
 
         /**
          * @brief Get the IP address of the observer.
@@ -140,11 +152,7 @@ namespace Coap
          *
          * @note Only the least significant 24 bits are used.
          */
-        uint32_t getNextSequentialNumber()
-        {
-            unsigned long currentTime = millis();
-            return currentTime & 0xFFFFFF; // Return only the least significant 24 bits.
-        }
+        uint32_t getNextSequentialNumber();
     };
 
     /**

--- a/src/Observers.h
+++ b/src/Observers.h
@@ -398,6 +398,28 @@ namespace Coap
         {
             return this->remove(observer.getIp(), observer.getPort(), observer.getToken(), observer.getTokenLength());
         }
+
+        /**
+         * @brief Process incoming responses to notifications sent to observers.
+         * @return
+         *
+         * This is a maintenance function that must be called in the response handler
+         * @ref setResponseHandler to keep observer state up to date.
+         * It will update the last seen timestamp of observers that have sent a response.
+         * It will also remove observers that have sent a RST response, as per specifications.
+         * @see https://datatracker.ietf.org/doc/html/rfc7641#section-4.5
+         *
+         * @example
+         */
+        ErrorCode processNotificationResponse(Message &message, IPAddress ip, uint16_t port)
+        {
+
+            // TODO: Look for outstanding notifications in the _retransmissionQueue sent to observers and match the response with the observer.
+            // Unclear how to do this, as the _retransmissionQueue is private to the ProsecCoAP class and not accessible from here.
+
+            // If the response is a RST, remove the observer from the registry.
+            // If the response is an ACK, update the last seen timestamp of the observer (by calling setActive(true)).
+        }
     };
 }
 

--- a/src/Observers.h
+++ b/src/Observers.h
@@ -398,28 +398,6 @@ namespace Coap
         {
             return this->remove(observer.getIp(), observer.getPort(), observer.getToken(), observer.getTokenLength());
         }
-
-        /**
-         * @brief Process incoming responses to notifications sent to observers.
-         * @return
-         *
-         * This is a maintenance function that must be called in the response handler
-         * @ref setResponseHandler to keep observer state up to date.
-         * It will update the last seen timestamp of observers that have sent a response.
-         * It will also remove observers that have sent a RST response, as per specifications.
-         * @see https://datatracker.ietf.org/doc/html/rfc7641#section-4.5
-         *
-         * @example
-         */
-        ErrorCode processNotificationResponse(Message &message, IPAddress ip, uint16_t port)
-        {
-
-            // TODO: Look for outstanding notifications in the _retransmissionQueue sent to observers and match the response with the observer.
-            // Unclear how to do this, as the _retransmissionQueue is private to the ProsecCoAP class and not accessible from here.
-
-            // If the response is a RST, remove the observer from the registry.
-            // If the response is an ACK, update the last seen timestamp of the observer (by calling setActive(true)).
-        }
     };
 }
 

--- a/src/ProsecCoAP.cpp
+++ b/src/ProsecCoAP.cpp
@@ -1207,8 +1207,6 @@ namespace Coap
                     }
                 }
             }
-            // err will be ErrorCode::NOT_FOUND if there are no more messages to read.
-            // REVIEW: err may also be another error code if something went wrong.
         }
 
         // !SECTION End of server mode.

--- a/src/ProsecCoAP.cpp
+++ b/src/ProsecCoAP.cpp
@@ -140,6 +140,13 @@ namespace Coap
             return err;
         }
 
+        if (observer.isStale())
+        {
+            // Use CON for stale observers, as per specifications.
+            // See https://datatracker.ietf.org/doc/html/rfc7641#section-4.5
+            this->setType(MessageType::CON);
+        }
+
         return ErrorCode::OK;
     }
 
@@ -1217,7 +1224,14 @@ namespace Coap
     {
         if (message.getType() == MessageType::CON)
         {
-            this->_retransmissionQueue.add(message, ip, port);
+            ErrorCode err = this->_retransmissionQueue.add(message, ip, port);
+            if (err != ErrorCode::OK)
+            {
+                // Failed to add to retransmission queue.
+                // Possibly full.
+                // A solution is to throttle requests or increase COAP_CONFIRMABLE_MESSAGE_QUEUE_SIZE.
+                return err;
+            }
         }
         return Detail::sendUdp(this->_udp, message.asRaw(), message.getLength(), ip, port);
     }

--- a/src/ProsecCoAP.cpp
+++ b/src/ProsecCoAP.cpp
@@ -140,13 +140,6 @@ namespace Coap
             return err;
         }
 
-        if (observer.isStale())
-        {
-            // Use CON for stale observers, as per specifications.
-            // See https://datatracker.ietf.org/doc/html/rfc7641#section-4.5
-            this->setType(MessageType::CON);
-        }
-
         return ErrorCode::OK;
     }
 

--- a/src/ProsecCoAP.h
+++ b/src/ProsecCoAP.h
@@ -680,7 +680,6 @@ namespace Coap
          * The message will be converted to notification, modifying:
          * - Token and its length, set as the token from the observer (any existing token will be overwritten).
          * - Observe option with the appropriate incremental value taken from the observer.
-         * - Promote the message to a CON message if the observer has not been seen in the last 24 hours.
          *
          * @note This does not set any other field. Other options to be set manually as necessary.
          *

--- a/src/ProsecCoAP.h
+++ b/src/ProsecCoAP.h
@@ -680,10 +680,12 @@ namespace Coap
          * The message will be converted to notification, modifying:
          * - Token and its length, set as the token from the observer (any existing token will be overwritten).
          * - Observe option with the appropriate incremental value taken from the observer.
+         * - Promote the message to a CON message if the observer has not been seen in the last 24 hours.
          *
          * @note This does not set any other field. Other options to be set manually as necessary.
          *
          * @see https://datatracker.ietf.org/doc/html/rfc7641#section-3.5
+         * @see https://datatracker.ietf.org/doc/html/rfc7641#section-4.5
          *
          * @param observer The observer to notify. The observer incremental value will be updated accordingly.
          * @return An error code indicating success or failure.


### PR DESCRIPTION
## 📝 Description
<!-- Describe the changes and why they were made. -->
This introduce helpers to monitor stale observers, particular:
- `bool Observer::isStale()`

## 🔗 Related Issue
<!-- Connect to the related issue, if any. -->
It does not close the related issue #11 because it does not provide a self-managed mechanism to update observers.

## ✅ Checklist
- [x] I've linked the corresponding issue using `Closes #XXX` syntax, if any.
- [x] I have performed a self-review of my own code.
- [x] I have sufficiently documented my code.
- [x] I followed any other indication specified by `README.md` and `CONTRIBUTING.md`.

## ℹ️ Additional info
