### PR TITLE
Utils refactoring for byte order conversions

### DIFF
--- a/src/Utils.h
+++ b/src/Utils.h
@@ -11,7 +11,6 @@
 namespace Coap
 {
     /**
-     * @namespace Utils
      * @brief Utilities.
      *
      * This namespace contains public utility functions and classes.
@@ -69,10 +68,6 @@ namespace Coap
             toNetworkByteOrder<8>(int_value, result);
         }
 
-        // ========================================================================
-        // UNSIGNED INTEGER READERS
-        // ========================================================================
-
         // NOTE: The host byte order (big/little endian) does not matter, as the bit shift operator
         // will adjust accordingly.
         // See https://commandcenter.blogspot.com/2012/04/byte-order-fallacy.html
@@ -112,10 +107,6 @@ namespace Coap
                    (static_cast<uint64_t>(bytes[7]));
         }
 
-        // ========================================================================
-        // SIGNED INTEGER READERS
-        // ========================================================================
-
         /**
          * @brief Reads a 16-bit signed integer from a Big-Endian byte stream.
          */
@@ -140,10 +131,6 @@ namespace Coap
         {
             return static_cast<int64_t>(read_uint64(bytes));
         }
-
-        // ========================================================================
-        // FLOATING POINT READERS
-        // ========================================================================
 
         /**
          * @brief Reads a 32-bit float from a Big-Endian byte stream.

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -37,7 +37,7 @@ namespace Coap
             for (size_t i = 0; i < N; ++i)
             {
                 // Shift right by (N - 1 - i) * 8 bits, then mask the lowest byte.
-                result[i] = static_cast<uint8_t>((value >> ((N - 1 - i) * 8)) & 0xFF); // NOTE: Right shift is defined behaviour also for signed integers.
+                result[i] = static_cast<uint8_t>((value >> ((N - 1 - i) * 8)) & 0xFF);
             }
 #endif
         }

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -27,11 +27,18 @@ namespace Coap::Utils
     template <size_t N, typename T>
     inline void toNetworkByteOrder(T value, uint8_t (&result)[N])
     {
+        static_assert(N == sizeof(T), "Array size N must match the size of type T.");
+#if defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+        // If the host is already big-endian, we can just memcpy the value.
+        memcpy(result, &value, N);
+#else
+        // The host is little endian, so we need to manually convert to big-endian.
         for (size_t i = 0; i < N; ++i)
         {
             // Shift right by (N - 1 - i) * 8 bits, then mask the lowest byte.
             result[i] = static_cast<uint8_t>((value >> ((N - 1 - i) * 8)) & 0xFF);
         }
+#endif
     }
 
     /**
@@ -43,10 +50,7 @@ namespace Coap::Utils
     inline void toNetworkByteOrder(float value, uint8_t (&result)[4])
     {
         uint32_t int_value;
-        // Safely grab the raw bits of the float without breaking strict-aliasing
         memcpy(&int_value, &value, sizeof(float));
-
-        // Pass the bits into your original integer template
         toNetworkByteOrder<4>(int_value, result);
     }
 
@@ -59,10 +63,7 @@ namespace Coap::Utils
     inline void toNetworkByteOrder(double value, uint8_t (&result)[8])
     {
         uint64_t int_value;
-        // Safely grab the raw bits of the double
         memcpy(&int_value, &value, sizeof(double));
-
-        // Pass the bits into your original integer template
         toNetworkByteOrder<8>(int_value, result);
     }
 

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -19,6 +19,9 @@ namespace Coap::Utils
     /**
      * @brief Convert an integer-like value to network byte order (i.e. big-endian).
      *
+     * @param value The integer-like value to convert.
+     * @param[out] result The array of bytes to store the result in.
+     *
      * The result must be stored in an array of bytes with the *exact* required size.
      */
     template <size_t N, typename T>
@@ -29,6 +32,38 @@ namespace Coap::Utils
             // Shift right by (N - 1 - i) * 8 bits, then mask the lowest byte.
             result[i] = static_cast<uint8_t>((value >> ((N - 1 - i) * 8)) & 0xFF);
         }
+    }
+
+    /**
+     * @brief Overload to convert a 32-bit float to network byte order.
+     *
+     * @param value The float value to convert.
+     * @param[out] result The array of bytes to store the result in.
+     */
+    inline void toNetworkByteOrder(float value, uint8_t (&result)[4])
+    {
+        uint32_t int_value;
+        // Safely grab the raw bits of the float without breaking strict-aliasing
+        memcpy(&int_value, &value, sizeof(float));
+
+        // Pass the bits into your original integer template
+        toNetworkByteOrder<4>(int_value, result);
+    }
+
+    /**
+     * @brief Overload to convert a 64-bit double to network byte order.
+     *
+     * @param value The double value to convert.
+     * @param[out] result The array of bytes to store the result in.
+     */
+    inline void toNetworkByteOrder(double value, uint8_t (&result)[8])
+    {
+        uint64_t int_value;
+        // Safely grab the raw bits of the double
+        memcpy(&int_value, &value, sizeof(double));
+
+        // Pass the bits into your original integer template
+        toNetworkByteOrder<8>(int_value, result);
     }
 
     // ========================================================================

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -20,10 +20,13 @@ namespace Coap
         /**
          * @brief Convert an integer-like value to network byte order (i.e. big-endian).
          *
-         * @param value The integer-like value to convert (both signed or unsigned).
+         * @param value The integer-like value to convert.
          * @param[out] result The array of bytes to store the result in.
          *
          * The result must be stored in an array of bytes with the *exact* required size.
+         *
+         * @note Both signed and unsigned integers are supported as long as the right-shift operator
+         * performs arithmetic right shift, so that the result remains negative.
          */
         template <size_t N, typename T>
         inline void toNetworkByteOrder(T value, uint8_t (&result)[N])

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -20,7 +20,7 @@ namespace Coap
         /**
          * @brief Convert an integer-like value to network byte order (i.e. big-endian).
          *
-         * @param value The integer-like value to convert.
+         * @param value The integer-like value to convert (both signed or unsigned).
          * @param[out] result The array of bytes to store the result in.
          *
          * The result must be stored in an array of bytes with the *exact* required size.
@@ -37,7 +37,7 @@ namespace Coap
             for (size_t i = 0; i < N; ++i)
             {
                 // Shift right by (N - 1 - i) * 8 bits, then mask the lowest byte.
-                result[i] = static_cast<uint8_t>((value >> ((N - 1 - i) * 8)) & 0xFF);
+                result[i] = static_cast<uint8_t>((value >> ((N - 1 - i) * 8)) & 0xFF); // NOTE: Right shift is defined behaviour also for signed integers.
             }
 #endif
         }

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -22,66 +22,117 @@ namespace Coap::Utils
      * The result must be stored in an array of bytes with the *exact* required size.
      */
     template <size_t N, typename T>
-    void toNetworkByteOrder(T value, uint8_t (&result)[N])
+    inline void toNetworkByteOrder(T value, uint8_t (&result)[N])
     {
         for (size_t i = 0; i < N; ++i)
         {
-            // Shift right by (N - 1 - i) * 8 bits, then mask the lowest byte
+            // Shift right by (N - 1 - i) * 8 bits, then mask the lowest byte.
             result[i] = static_cast<uint8_t>((value >> ((N - 1 - i) * 8)) & 0xFF);
         }
     }
 
+    // ========================================================================
+    // UNSIGNED INTEGER READERS
+    // ========================================================================
+
+    // NOTE: The host byte order (big/little endian) does not matter, as the bit shift operator
+    // will adjust accordingly.
+    // See https://commandcenter.blogspot.com/2012/04/byte-order-fallacy.html
+
     /**
-     * @brief Custom implementation of ntohs (Network to Host Short) for 16-bit integers.
+     * @brief Reads a 16-bit unsigned integer from a Big-Endian byte stream.
      */
-    inline constexpr uint16_t ntohs(uint16_t net_short)
+    inline constexpr uint16_t read_uint16(const uint8_t *bytes)
     {
-#if defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-        // If the native platform is already Big-Endian, do nothing
-        return net_short;
-#else
-        // On Little-Endian, swap the 2 bytes
-        return static_cast<uint16_t>((((net_short) & 0xFF00u) >> 8) |
-                                     (((net_short) & 0x00FFu) << 8));
-#endif
+        return static_cast<uint16_t>((static_cast<uint16_t>(bytes[0]) << 8) |
+                                     static_cast<uint16_t>(bytes[1]));
     }
 
     /**
-     * @brief Custom implementation of ntohl (Network to Host Long) for 32-bit integers.
+     * @brief Reads a 32-bit unsigned integer from a Big-Endian byte stream.
      */
-    inline constexpr uint32_t ntohl(uint32_t net_long)
+    inline constexpr uint32_t read_uint32(const uint8_t *bytes)
     {
-#if defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-        // If the native platform is already Big-Endian, do nothing
-        return net_long;
-#else
-        // On Little-Endian, swap the 4 bytes
-        return (((net_long & 0xFF000000ul) >> 24) |
-                ((net_long & 0x00FF0000ul) >> 8) |
-                ((net_long & 0x0000FF00ul) << 8) |
-                ((net_long & 0x000000FFul) << 24));
-#endif
+        return (static_cast<uint32_t>(bytes[0]) << 24) |
+               (static_cast<uint32_t>(bytes[1]) << 16) |
+               (static_cast<uint32_t>(bytes[2]) << 8) |
+               (static_cast<uint32_t>(bytes[3]));
     }
 
     /**
-     * @brief Custom implementation of ntohll (Network to Host Long Long) for 64-bit integers.
+     * @brief Reads a 64-bit unsigned integer from a Big-Endian byte stream.
      */
-    inline constexpr uint64_t ntohll(uint64_t net_longlong)
+    inline constexpr uint64_t read_uint64(const uint8_t *bytes)
     {
-#if defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-        // If the native platform is already Big-Endian, do nothing
-        return net_longlong;
-#else
-        // On Little-Endian, swap the 8 bytes
-        return (((net_longlong & 0xFF00000000000000ull) >> 56) |
-                ((net_longlong & 0x00FF000000000000ull) >> 40) |
-                ((net_longlong & 0x0000FF0000000000ull) >> 24) |
-                ((net_longlong & 0x000000FF00000000ull) >> 8) |
-                ((net_longlong & 0x00000000FF000000ull) << 8) |
-                ((net_longlong & 0x0000000000FF0000ull) << 24) |
-                ((net_longlong & 0x000000000000FF00ull) << 40) |
-                ((net_longlong & 0x00000000000000FFull) << 56));
-#endif
+        return (static_cast<uint64_t>(bytes[0]) << 56) |
+               (static_cast<uint64_t>(bytes[1]) << 48) |
+               (static_cast<uint64_t>(bytes[2]) << 40) |
+               (static_cast<uint64_t>(bytes[3]) << 32) |
+               (static_cast<uint64_t>(bytes[4]) << 24) |
+               (static_cast<uint64_t>(bytes[5]) << 16) |
+               (static_cast<uint64_t>(bytes[6]) << 8) |
+               (static_cast<uint64_t>(bytes[7]));
+    }
+
+    // ========================================================================
+    // SIGNED INTEGER READERS
+    // ========================================================================
+
+    /**
+     * @brief Reads a 16-bit signed integer from a Big-Endian byte stream.
+     */
+    inline constexpr int16_t read_int16(const uint8_t *bytes)
+    {
+        // Read as unsigned to avoid bitshift UB, then cast to signed.
+        return static_cast<int16_t>(read_uint16(bytes));
+    }
+
+    /**
+     * @brief Reads a 32-bit signed integer from a Big-Endian byte stream.
+     */
+    inline constexpr int32_t read_int32(const uint8_t *bytes)
+    {
+        return static_cast<int32_t>(read_uint32(bytes));
+    }
+
+    /**
+     * @brief Reads a 64-bit signed integer from a Big-Endian byte stream.
+     */
+    inline constexpr int64_t read_int64(const uint8_t *bytes)
+    {
+        return static_cast<int64_t>(read_uint64(bytes));
+    }
+
+    // ========================================================================
+    // FLOATING POINT READERS
+    // ========================================================================
+
+    /**
+     * @brief Reads a 32-bit float from a Big-Endian byte stream.
+     */
+    inline float read_float(const uint8_t *bytes)
+    {
+        // Reuse the unsigned reader to safely reconstruct the bits
+        uint32_t value = read_uint32(bytes);
+        float host_float;
+
+        // Safely copy the reconstructed bits into the float
+        memcpy(&host_float, &value, sizeof(float));
+        return host_float;
+    }
+
+    /**
+     * @brief Reads a 64-bit double from a Big-Endian byte stream.
+     */
+    inline double read_double(const uint8_t *bytes)
+    {
+        // Reuse the unsigned reader to safely reconstruct the bits
+        uint64_t value = read_uint64(bytes);
+        double host_double;
+
+        // Safely copy the reconstructed bits into the double
+        memcpy(&host_double, &value, sizeof(double));
+        return host_double;
     }
 }
 

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -8,167 +8,168 @@
 #include <Arduino.h>
 #include <stdint.h>
 
-/**
- * @namespace Coap::Utils
- * @brief Utilities.
- *
- * This namespace contains public utility functions and classes.
- */
-namespace Coap::Utils
+namespace Coap
 {
     /**
-     * @brief Convert an integer-like value to network byte order (i.e. big-endian).
+     * @namespace Utils
+     * @brief Utilities.
      *
-     * @param value The integer-like value to convert.
-     * @param[out] result The array of bytes to store the result in.
-     *
-     * The result must be stored in an array of bytes with the *exact* required size.
+     * This namespace contains public utility functions and classes.
      */
-    template <size_t N, typename T>
-    inline void toNetworkByteOrder(T value, uint8_t (&result)[N])
+    namespace Utils
     {
-        static_assert(N == sizeof(T), "Array size N must match the size of type T.");
-#if defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-        // If the host is already big-endian, we can just memcpy the value.
-        memcpy(result, &value, N);
-#else
-        // The host is little endian, so we need to manually convert to big-endian.
-        for (size_t i = 0; i < N; ++i)
+        /**
+         * @brief Convert an integer-like value to network byte order (i.e. big-endian).
+         *
+         * @param value The integer-like value to convert.
+         * @param[out] result The array of bytes to store the result in.
+         *
+         * The result must be stored in an array of bytes with the *exact* required size.
+         */
+        template <size_t N, typename T>
+        inline void toNetworkByteOrder(T value, uint8_t (&result)[N])
         {
-            // Shift right by (N - 1 - i) * 8 bits, then mask the lowest byte.
-            result[i] = static_cast<uint8_t>((value >> ((N - 1 - i) * 8)) & 0xFF);
-        }
+            static_assert(N == sizeof(T), "Array size N must match the size of type T.");
+#if defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+            // If the host is already big-endian, we can just memcpy the value.
+            memcpy(result, &value, N);
+#else
+            // The host is little endian, so we need to manually convert to big-endian.
+            for (size_t i = 0; i < N; ++i)
+            {
+                // Shift right by (N - 1 - i) * 8 bits, then mask the lowest byte.
+                result[i] = static_cast<uint8_t>((value >> ((N - 1 - i) * 8)) & 0xFF);
+            }
 #endif
-    }
+        }
 
-    /**
-     * @brief Overload to convert a 32-bit float to network byte order.
-     *
-     * @param value The float value to convert.
-     * @param[out] result The array of bytes to store the result in.
-     */
-    inline void toNetworkByteOrder(float value, uint8_t (&result)[4])
-    {
-        uint32_t int_value;
-        memcpy(&int_value, &value, sizeof(float));
-        toNetworkByteOrder<4>(int_value, result);
-    }
+        /**
+         * @brief Overload to convert a 32-bit float to network byte order.
+         *
+         * @param value The float value to convert.
+         * @param[out] result The array of bytes to store the result in.
+         */
+        inline void toNetworkByteOrder(float value, uint8_t (&result)[4])
+        {
+            uint32_t int_value;
+            memcpy(&int_value, &value, sizeof(float));
+            toNetworkByteOrder<4>(int_value, result);
+        }
 
-    /**
-     * @brief Overload to convert a 64-bit double to network byte order.
-     *
-     * @param value The double value to convert.
-     * @param[out] result The array of bytes to store the result in.
-     */
-    inline void toNetworkByteOrder(double value, uint8_t (&result)[8])
-    {
-        uint64_t int_value;
-        memcpy(&int_value, &value, sizeof(double));
-        toNetworkByteOrder<8>(int_value, result);
-    }
+        /**
+         * @brief Overload to convert a 64-bit double to network byte order.
+         *
+         * @param value The double value to convert.
+         * @param[out] result The array of bytes to store the result in.
+         */
+        inline void toNetworkByteOrder(double value, uint8_t (&result)[8])
+        {
+            uint64_t int_value;
+            memcpy(&int_value, &value, sizeof(double));
+            toNetworkByteOrder<8>(int_value, result);
+        }
 
-    // ========================================================================
-    // UNSIGNED INTEGER READERS
-    // ========================================================================
+        // ========================================================================
+        // UNSIGNED INTEGER READERS
+        // ========================================================================
 
-    // NOTE: The host byte order (big/little endian) does not matter, as the bit shift operator
-    // will adjust accordingly.
-    // See https://commandcenter.blogspot.com/2012/04/byte-order-fallacy.html
+        // NOTE: The host byte order (big/little endian) does not matter, as the bit shift operator
+        // will adjust accordingly.
+        // See https://commandcenter.blogspot.com/2012/04/byte-order-fallacy.html
 
-    /**
-     * @brief Reads a 16-bit unsigned integer from a Big-Endian byte stream.
-     */
-    inline constexpr uint16_t read_uint16(const uint8_t *bytes)
-    {
-        return static_cast<uint16_t>((static_cast<uint16_t>(bytes[0]) << 8) |
-                                     static_cast<uint16_t>(bytes[1]));
-    }
+        /**
+         * @brief Reads a 16-bit unsigned integer from a Big-Endian byte stream.
+         */
+        inline constexpr uint16_t read_uint16(const uint8_t *bytes)
+        {
+            return static_cast<uint16_t>((static_cast<uint16_t>(bytes[0]) << 8) |
+                                         static_cast<uint16_t>(bytes[1]));
+        }
 
-    /**
-     * @brief Reads a 32-bit unsigned integer from a Big-Endian byte stream.
-     */
-    inline constexpr uint32_t read_uint32(const uint8_t *bytes)
-    {
-        return (static_cast<uint32_t>(bytes[0]) << 24) |
-               (static_cast<uint32_t>(bytes[1]) << 16) |
-               (static_cast<uint32_t>(bytes[2]) << 8) |
-               (static_cast<uint32_t>(bytes[3]));
-    }
+        /**
+         * @brief Reads a 32-bit unsigned integer from a Big-Endian byte stream.
+         */
+        inline constexpr uint32_t read_uint32(const uint8_t *bytes)
+        {
+            return (static_cast<uint32_t>(bytes[0]) << 24) |
+                   (static_cast<uint32_t>(bytes[1]) << 16) |
+                   (static_cast<uint32_t>(bytes[2]) << 8) |
+                   (static_cast<uint32_t>(bytes[3]));
+        }
 
-    /**
-     * @brief Reads a 64-bit unsigned integer from a Big-Endian byte stream.
-     */
-    inline constexpr uint64_t read_uint64(const uint8_t *bytes)
-    {
-        return (static_cast<uint64_t>(bytes[0]) << 56) |
-               (static_cast<uint64_t>(bytes[1]) << 48) |
-               (static_cast<uint64_t>(bytes[2]) << 40) |
-               (static_cast<uint64_t>(bytes[3]) << 32) |
-               (static_cast<uint64_t>(bytes[4]) << 24) |
-               (static_cast<uint64_t>(bytes[5]) << 16) |
-               (static_cast<uint64_t>(bytes[6]) << 8) |
-               (static_cast<uint64_t>(bytes[7]));
-    }
+        /**
+         * @brief Reads a 64-bit unsigned integer from a Big-Endian byte stream.
+         */
+        inline constexpr uint64_t read_uint64(const uint8_t *bytes)
+        {
+            return (static_cast<uint64_t>(bytes[0]) << 56) |
+                   (static_cast<uint64_t>(bytes[1]) << 48) |
+                   (static_cast<uint64_t>(bytes[2]) << 40) |
+                   (static_cast<uint64_t>(bytes[3]) << 32) |
+                   (static_cast<uint64_t>(bytes[4]) << 24) |
+                   (static_cast<uint64_t>(bytes[5]) << 16) |
+                   (static_cast<uint64_t>(bytes[6]) << 8) |
+                   (static_cast<uint64_t>(bytes[7]));
+        }
 
-    // ========================================================================
-    // SIGNED INTEGER READERS
-    // ========================================================================
+        // ========================================================================
+        // SIGNED INTEGER READERS
+        // ========================================================================
 
-    /**
-     * @brief Reads a 16-bit signed integer from a Big-Endian byte stream.
-     */
-    inline constexpr int16_t read_int16(const uint8_t *bytes)
-    {
-        // Read as unsigned to avoid bitshift UB, then cast to signed.
-        return static_cast<int16_t>(read_uint16(bytes));
-    }
+        /**
+         * @brief Reads a 16-bit signed integer from a Big-Endian byte stream.
+         */
+        inline constexpr int16_t read_int16(const uint8_t *bytes)
+        {
+            // Read as unsigned to avoid bitshift undefined behaviour, then cast to signed.
+            return static_cast<int16_t>(read_uint16(bytes));
+        }
 
-    /**
-     * @brief Reads a 32-bit signed integer from a Big-Endian byte stream.
-     */
-    inline constexpr int32_t read_int32(const uint8_t *bytes)
-    {
-        return static_cast<int32_t>(read_uint32(bytes));
-    }
+        /**
+         * @brief Reads a 32-bit signed integer from a Big-Endian byte stream.
+         */
+        inline constexpr int32_t read_int32(const uint8_t *bytes)
+        {
+            return static_cast<int32_t>(read_uint32(bytes));
+        }
 
-    /**
-     * @brief Reads a 64-bit signed integer from a Big-Endian byte stream.
-     */
-    inline constexpr int64_t read_int64(const uint8_t *bytes)
-    {
-        return static_cast<int64_t>(read_uint64(bytes));
-    }
+        /**
+         * @brief Reads a 64-bit signed integer from a Big-Endian byte stream.
+         */
+        inline constexpr int64_t read_int64(const uint8_t *bytes)
+        {
+            return static_cast<int64_t>(read_uint64(bytes));
+        }
 
-    // ========================================================================
-    // FLOATING POINT READERS
-    // ========================================================================
+        // ========================================================================
+        // FLOATING POINT READERS
+        // ========================================================================
 
-    /**
-     * @brief Reads a 32-bit float from a Big-Endian byte stream.
-     */
-    inline float read_float(const uint8_t *bytes)
-    {
-        // Reuse the unsigned reader to safely reconstruct the bits
-        uint32_t value = read_uint32(bytes);
-        float host_float;
+        /**
+         * @brief Reads a 32-bit float from a Big-Endian byte stream.
+         */
+        inline float read_float(const uint8_t *bytes)
+        {
+            uint32_t value = read_uint32(bytes);
+            float host_float;
+            memcpy(&host_float, &value, sizeof(float));
+            return host_float;
+        }
 
-        // Safely copy the reconstructed bits into the float
-        memcpy(&host_float, &value, sizeof(float));
-        return host_float;
-    }
-
-    /**
-     * @brief Reads a 64-bit double from a Big-Endian byte stream.
-     */
-    inline double read_double(const uint8_t *bytes)
-    {
-        // Reuse the unsigned reader to safely reconstruct the bits
-        uint64_t value = read_uint64(bytes);
-        double host_double;
-
-        // Safely copy the reconstructed bits into the double
-        memcpy(&host_double, &value, sizeof(double));
-        return host_double;
+        /**
+         * @brief Reads a 64-bit double from a Big-Endian byte stream.
+         *
+         * @note Templated to defer the 64-bit architecture check until the function is actually called.
+         */
+        template <typename T = double>
+        inline T read_double(const uint8_t *bytes)
+        {
+            static_assert(sizeof(T) == 8, "Cannot read a 64-bit network double on a 32-bit double architecture (like AVR).");
+            uint64_t value = read_uint64(bytes);
+            double host_double;
+            memcpy(&host_double, &value, sizeof(double));
+            return host_double;
+        }
     }
 }
 


### PR DESCRIPTION
## 📝 Description
Cleared the conversion utilities to and from network byte order to make:
- conversion from host byte order to network (big-endian) for all standard types
- conversion from network (big-endian) to host for all standard types
- removed the ntohl and family as they are not useful with CoAP message handling (based on `uint8_t*`).

## 🔗 Related Issue
None

## ✅ Checklist
- [x] I've linked the corresponding issue using `Closes #XXX` syntax, if any.
- [x] I have performed a self-review of my own code.
- [x] I have sufficiently documented my code.
- [x] I followed any other indication specified by `README.md` and `CONTRIBUTING.md`.

## ℹ️ Additional info
